### PR TITLE
Added docker_restart_on_package_change to handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart docker
   service: name=docker state=restarted
+  when: docker_restart_on_package_change


### PR DESCRIPTION
- docker_restart_on_package_change now controls whether a restart of docker will occur when the handler is triggered